### PR TITLE
Using correct device information

### DIFF
--- a/bugbattle/src/main/java/bugbattle/io/bugbattle/model/FeedbackModel.java
+++ b/bugbattle/src/main/java/bugbattle/io/bugbattle/model/FeedbackModel.java
@@ -2,6 +2,7 @@ package bugbattle.io.bugbattle.model;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.support.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -28,14 +29,13 @@ public class FeedbackModel {
     private Bitmap screenshot;
 
     private JSONObject customData;
-    private PhoneMeta phoneMeta;
+    private @Nullable PhoneMeta phoneMeta;
     private LogReader logReader;
     private StepsToReproduce stepsToReproduce;
     private ShakeGestureDetector shakeGestureDetector;
 
 
     private FeedbackModel() {
-        phoneMeta = new PhoneMeta();
         logReader = new LogReader();
         stepsToReproduce = StepsToReproduce.getInstance();
         customData = new JSONObject();
@@ -48,7 +48,7 @@ public class FeedbackModel {
         return instance;
     }
 
-    public PhoneMeta getPhoneMeta() {
+    public @Nullable PhoneMeta  getPhoneMeta() {
         return phoneMeta;
     }
 
@@ -98,6 +98,7 @@ public class FeedbackModel {
 
     public void setContext(Context context) {
         this.context = context;
+        phoneMeta = new PhoneMeta(context);
     }
 
     public String getAppBarColor() {

--- a/bugbattle/src/main/java/bugbattle/io/bugbattle/model/PhoneMeta.java
+++ b/bugbattle/src/main/java/bugbattle/io/bugbattle/model/PhoneMeta.java
@@ -4,10 +4,12 @@ import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 
 import org.json.JSONException;
@@ -33,9 +35,9 @@ public class PhoneMeta {
     private static String buildVersionNumber;
     private static String releaseVersionNumber;
 
-    public PhoneMeta() {
+    public PhoneMeta(@NonNull Context context) {
         startTime = new Date().getTime();
-        getPhoneMeta();
+        getPhoneMeta(context);
     }
 
     /**
@@ -59,14 +61,28 @@ public class PhoneMeta {
         return obj;
     }
 
-    private void getPhoneMeta() {
+    private void getPhoneMeta(Context context) {
+        PackageManager packageManager = context.getPackageManager();
+        if (packageManager != null) {
+            try {
+                PackageInfo packageInfo = packageManager.getPackageInfo(context.getPackageName(), 0);
+                buildVersionNumber = Integer.toString(packageInfo.versionCode);
+                releaseVersionNumber = packageInfo.versionName;
+                bundleID = packageInfo.packageName;
+            } catch (PackageManager.NameNotFoundException e) {
+                e.printStackTrace();
+                buildVersionNumber = Integer.toString(BuildConfig.VERSION_CODE);
+                releaseVersionNumber = BuildConfig.VERSION_NAME;
+                //noinspection deprecation
+                bundleID = BuildConfig.APPLICATION_ID;
+
+            }
+        }
+
         deviceModel = Build.MODEL;
-        deviceName = Build.MODEL;
-        bundleID = BuildConfig.APPLICATION_ID;
+        deviceName = Build.DEVICE;
         systemName = "Android";
         systemVersion = Build.VERSION.RELEASE;
-        buildVersionNumber = Integer.toString(BuildConfig.VERSION_CODE);
-        releaseVersionNumber = BuildConfig.VERSION_NAME;
     }
 
     private static String calculateDuration() {

--- a/bugbattle/src/main/java/bugbattle/io/bugbattle/service/HttpHelper.java
+++ b/bugbattle/src/main/java/bugbattle/io/bugbattle/service/HttpHelper.java
@@ -20,6 +20,7 @@ import javax.net.ssl.HttpsURLConnection;
 
 import bugbattle.io.bugbattle.controller.OnHttpResponseListener;
 import bugbattle.io.bugbattle.model.FeedbackModel;
+import bugbattle.io.bugbattle.model.PhoneMeta;
 
 /**
  * Sends the report to the bugbattle dashboard.
@@ -71,7 +72,10 @@ public class HttpHelper extends AsyncTask<FeedbackModel, Void, Integer> {
         result.put("screenshot", imageURL);
         result.put("description", service.getDescription());
         result.put("reportedBy", service.getEmail());
-        result.put("meta", service.getPhoneMeta().getJSONObj());
+        PhoneMeta phoneMeta = service.getPhoneMeta();
+        if (phoneMeta != null) {
+            result.put("meta", phoneMeta.getJSONObj());
+        }
         result.put("consoleLog", service.getLogs());
         result.put("actionLog", service.getStepsToReproduce());
         result.put("customData", service.getCustomData());


### PR DESCRIPTION
Using `Context` to get package information. 

- Device name was the same as device model
- Package name was getting the package name of the library rather than the calling applications package
- Build version code and name retrieved at runtime. Compile time version name and code could be overwritten in the `build.gradle` using `setVersionNameOverride` and `setVersionCodeOverride`. 